### PR TITLE
Update scraper to accommodate new website format (#131)

### DIFF
--- a/finviz/helper_functions/scraper_functions.py
+++ b/finviz/helper_functions/scraper_functions.py
@@ -20,10 +20,9 @@ def get_table(page_html: requests.Response, headers, rows=None, **kwargs):
 
     data_sets = []
     # Select the HTML of the rows and append each column text to a list
-    # Skip the first element ([1:]), since it's the headers (we already have it as a constant)
     all_rows = [
         column.xpath("td//text()")
-        for column in page_parsed.cssselect('tr[valign="top"]')[1 : rows + 1]
+        for column in page_parsed.cssselect('tr[valign="top"]')
     ]
 
     # If rows is different from -2, this function is called from Screener


### PR DESCRIPTION
* Update scraper to accommodate new website format

Finviz has changed the header row to `<tr valign="middle">`, so skipping element 0 now skips a ticker. Fixed to no longer skip element 0 so that all stocks are retrieved.

* Update finviz/helper_functions/scraper_functions.py

Co-authored-by: diridevelops <61793898+diridevelops@users.noreply.github.com>

* Update scraper_functions.py

Co-authored-by: diridevelops <61793898+diridevelops@users.noreply.github.com>